### PR TITLE
5/9 17:16 모바일에서 이미지 업로드 시 이미지 회전이 되는 문제를 수정했습니다.

### DIFF
--- a/ggukgguk/pom.xml
+++ b/ggukgguk/pom.xml
@@ -246,6 +246,14 @@
 			<artifactId>KOMORAN</artifactId>
 			<version>3.3.9</version>
 		</dependency>		
+		
+		<!-- 이미지 처리 -->
+		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-imaging -->
+		<dependency>
+		    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-imaging</artifactId>
+		    <version>1.0-alpha3</version>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>


### PR DESCRIPTION
해당 이슈는 이미지 리사이징 시 이미지의 EXIF 메타데이터가 날아가버려 발생하는 문제였습니다.

[참고](https://exhibitlove.tistory.com/291)

모바일에서 세로로 사진 촬영시, 물리적으로 이미지의 픽셀이 90도 돌아가는 것이 아니라, EXIF에 저장된 메타데이터 값이 변하게 됩니다. 그럼 사진을 렌더링할 때 메타데이터를 읽어 사진 픽셀을 회전하여 보여주는 것입니다.

그러나 기존 서버에서는 이미지를 리사이징하는 과정에서 단순히 픽셀의 개수만을 줄였기 때문에 원본 파일의 메타데이터는 그대로 날아가게 됩니다.
따라서 이미지 리사이징 전 메타데이터를 추출해두고, 이미지 리사이징 후 다시 메타데이터를 덮어 씌우는 식으로 문제를 해결하였습니다.

